### PR TITLE
Create default requestOptions object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,8 @@ module.exports = function hapiPassport(prototype) {
         def(options, "onSuccess", options.successRedirect ? onSuccessRedirect : onSuccessDefault);
 
         return function processLogin(request, reply, requestOptions) {
+            requestOptions = requestOptions || {};
+
             strategy.redirect = function (url) {
                 reply().redirect(url);
             };


### PR DESCRIPTION
I'm trying to use this library with [https://github.com/bergie/passport-saml](https://github.com/bergie/passport-saml) - it fails when it tries to access properties of requestOptions which is undefined.  Creating a default empty requestOptions object solves this.
